### PR TITLE
Change deprecated compile method to implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,5 +43,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-dev-menu-android",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This MR changes the deprecated `compile` method to `implementation` gradle method.